### PR TITLE
Fix name clash on GHC 7.4.2.

### DIFF
--- a/src/Reactive/Bacon/EventStream/Monadic.hs
+++ b/src/Reactive/Bacon/EventStream/Monadic.hs
@@ -5,7 +5,7 @@ import Reactive.Bacon.Core
 import Reactive.Bacon.EventStream.Combinators
 import Reactive.Bacon.EventStream
 import Reactive.Bacon.PushStream(wrap)
-import Control.Concurrent.STM
+import Control.Concurrent.STM hiding (modifyTVar)
 import Control.Monad
 
 -- EventStream is not a Monad


### PR DESCRIPTION
Without this fix, the build fails due to modifyTVar being imported from two different sources:

[6 of 9] Compiling Reactive.Bacon.EventStream.Monadic ( src/Reactive/Bacon/EventStream/Monadic.hs, dist/build/Reactive/Bacon/EventStream/Monadic.o )

src/Reactive/Bacon/EventStream/Monadic.hs:18:18:
    Ambiguous occurrence `modifyTVar'
    It could refer to either`Reactive.Bacon.EventStream.Monadic.modifyTVar',
                             defined at src/Reactive/Bacon/EventStream/Monadic.hs:73:1
                          or `Control.Concurrent.STM.modifyTVar',
                             imported from`Control.Concurrent.STM' at src/Reactive/Bacon/EventStream/Monadic.hs:8:1-29
                             (and originally defined in `Control.Concurrent.STM.TVar')

Signed-off-by: Ville Peurala ville.peurala@gmail.com
